### PR TITLE
Fix error with display current pet sex in edit form

### DIFF
--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -14,7 +14,7 @@
   <%= text_field_tag :approximate_age, @pet.approximate_age %><br>
 
   <%= label_tag :sex %>
-  <%= select_tag :sex, options_for_select(['Male', 'Female']), default: @pet.sex %><br>
+  <%= select_tag :sex, options_for_select(['Male', 'Female'], @pet.sex) %><br>
 
   <%= submit_tag 'Update Pet' %>
 


### PR DESCRIPTION
This PR fixes the error that the pet's original sex wasn't auto-populating correctly in edit view.

It is now working as expected, with all tests passing.

Ready to merge into master